### PR TITLE
max-body-size param

### DIFF
--- a/src/jsoup/soup.clj
+++ b/src/jsoup/soup.clj
@@ -9,7 +9,8 @@
 
 (def ^:private params 
   ["user-agent" "cookies", "data", "method", "referrer", "timeout", 
-   "url", "follow-redirects", "ignore-content-type", "ignore-http-errors"])
+   "url", "follow-redirects", "ignore-content-type", "ignore-http-errors",
+   "max-body-size"])
 
 (defn- to-fn-name [name] 
   (let [words (clojure.string/split name #"[\s_-]+")] 


### PR DESCRIPTION
I added "max-body-size" to the params, see http://jsoup.org/apidocs/org/jsoup/Connection.html#maxBodySize-int-. I tried the change manually, and I was able to parse a 2-MB web page.
